### PR TITLE
moved read input into private classe; changed include file in .cpp file

### DIFF
--- a/local_density_potential/pair_localdensity.cpp
+++ b/local_density_potential/pair_localdensity.cpp
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------
+/* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
@@ -15,11 +15,12 @@
    Contributing authors: Tanmoy Sanyal, M.Scott Shell, UC Santa Barbara
 ------------------------------------------------------------------------- */
 
-#include "math.h"
-#include "stdio.h"
-#include "stdlib.h"
-#include "string.h"
 #include "pair_localdensity.h"
+#include <mpi.h>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <string>
 #include "atom.h"
 #include "force.h"
 #include "comm.h"

--- a/local_density_potential/pair_localdensity.h
+++ b/local_density_potential/pair_localdensity.h
@@ -1,4 +1,4 @@
-/* ----------------------------------------------------------------------
+/* -*- c++ -*- ----------------------------------------------------------
    LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
    http://lammps.sandia.gov, Sandia National Laboratories
    Steve Plimpton, sjplimp@sandia.gov
@@ -20,29 +20,12 @@ PairStyle(localdensity,PairLOCALDENSITY)
 #ifndef LMP_PAIR_LOCALDENSITY_H
 #define LMP_PAIR_LOCALDENSITY_H
 
-#include "stdio.h"
 #include "pair.h"
 
 namespace LAMMPS_NS {
 
 class PairLOCALDENSITY : public Pair {
  public:
-
-  // public variables 
-
-  double cutmax;
-
-  // data parsed from input file
-
-  int nLD, nrho;	
-  int **a, **b; // central and neighbor atom filters respectively
-  double *uppercut, *lowercut, *uppercutsq, *lowercutsq, *c0, *c2, *c4, *c6; 
-  double **frho, **rho, *rho_min, *rho_max, *delta_rho;
-
-  // potentials in spline form used for force computation
-
-  double ***frho_spline;
-
   PairLOCALDENSITY(class LAMMPS *);
   virtual ~PairLOCALDENSITY();
   virtual void compute(int, int);
@@ -59,6 +42,19 @@ class PairLOCALDENSITY : public Pair {
   double memory_usage();
 
  protected:
+   double cutmax;
+
+  // data parsed from input file
+
+  int nLD, nrho;
+  int **a, **b; // central and neighbor atom filters respectively
+  double *uppercut, *lowercut, *uppercutsq, *lowercutsq, *c0, *c2, *c4, *c6;
+  double **frho, **rho, *rho_min, *rho_max, *delta_rho;
+
+  // potentials in spline form used for force computation
+
+  double ***frho_spline;
+
   int nmax;                   // allocated size of per-atom arrays
   double cutforcesq;          // square of global upper cutoff
 


### PR DESCRIPTION
I've changed the included header files in the .cpp file to what I think is the most recent version.
I've further moved the "read from input part" in header file from public to private class.
The reason why I did that is that most pair styles do it that way.
I've later seen that EAM potentials do it differently, so don't know which way you want to have it.

Code compiles in serial and parallel and I could launch a test run.

